### PR TITLE
React perf follow-ups: hoist Portfolio sort, hoist Footer year, drop trivial useMemos

### DIFF
--- a/src/components/Footer/index.jsx
+++ b/src/components/Footer/index.jsx
@@ -2,9 +2,12 @@ import { memo } from "react";
 import ICON_BY_KEY from "../../data/iconMap";
 import { socialLinks } from "../../data/socialLinks";
 
-function Footer() {
-  const currentYear = new Date().getFullYear();
+// Captured once at module init; portfolio footer is static enough that we
+// accept the tab-open-across-New-Year staleness in exchange for skipping
+// per-mount Date allocation.
+const currentYear = new Date().getFullYear();
 
+function Footer() {
   return (
     <footer className="footer-shell">
       <ul className="footer-links" aria-label="Social links">

--- a/src/components/Portfolio/index.jsx
+++ b/src/components/Portfolio/index.jsx
@@ -1,11 +1,22 @@
-import { memo, useMemo, useState } from "react";
+import { memo, useState } from "react";
 import { projects } from "../../data/projects";
 import RevealItem from "../RevealItem";
 
+// Hoisted: `projects` is a module-static array, so the priority order never
+// changes between renders. Doing this at module scope avoids a per-mount
+// useMemo and the array allocation it would cache.
+const projectsByPriority = [
+  ...projects.filter((project) => project.featured),
+  ...projects.filter((project) => !project.featured),
+];
+
 const ProjectCard = memo(function ProjectCard({ project, isLead = false, index = 0 }) {
   const [imageFailed, setImageFailed] = useState(!project.image);
-  const coverTags = useMemo(() => project.tags.slice(0, 3), [project.tags]);
-  const stack = useMemo(() => project.tags.slice(0, 4).join(" • "), [project.tags]);
+  // Cheap slice + join — useMemo's bookkeeping costs more than the work and
+  // the parent <ProjectCard /> is already memo'd, so reference stability of
+  // the array doesn't buy anything downstream.
+  const coverTags = project.tags.slice(0, 3);
+  const stack = project.tags.slice(0, 4).join(" • ");
   const previewHref = project.demo || project.repo;
   const previewLabel = project.demo ? `${project.name} live demo` : `${project.name} repository`;
   const cardClass = [
@@ -116,12 +127,6 @@ const ProjectCard = memo(function ProjectCard({ project, isLead = false, index =
 });
 
 function Portfolio() {
-  const projectsByPriority = useMemo(() => {
-    const featured = projects.filter((project) => project.featured);
-    const standard = projects.filter((project) => !project.featured);
-    return [...featured, ...standard];
-  }, []);
-
   return (
     <section className="portfolio-panel portfolio-panel--minimal">
       <p className="section-eyebrow">


### PR DESCRIPTION
Follow-ups from the /vercel:react-best-practices pass.

- **Portfolio**: hoist `projectsByPriority` to module scope (\`projects\` never changes at runtime)
- **Portfolio**: drop \`useMemo\` around \`project.tags.slice(0, 3)\` and \`.slice(0, 4).join(...)\` — \`rerender-simple-expression-in-memo\`: bookkeeping costs more than the work, and \`ProjectCard\` is already memo'd
- **Footer**: hoist \`currentYear\` to module init (Footer is memo'd, savings are tiny but intent is clearer)

## Verification
- \`npm run check\` → 25/25 tests pass
- \`VISUAL_SMOKE_PORT=4174 npm run visual:smoke\` → 12/12 scenarios pass
- Bundle gzip: 73.32 kB → **73.29 kB** (-30 B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)