### PR TITLE
Audit pass: remove dead CSS, cheapen image hover, add sitemap

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+
+Sitemap: https://coleyrockin.github.io/react-portfolio/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://coleyrockin.github.io/react-portfolio/</loc>
+    <lastmod>2026-05-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/src/editorial.css
+++ b/src/editorial.css
@@ -466,17 +466,6 @@ a {
   text-wrap: balance;
 }
 
-.hero-meta {
-  margin: 1rem auto 0;
-  max-width: 48ch;
-  color: var(--faint);
-  font-size: 0.78rem;
-  font-weight: var(--weight-label);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  text-wrap: balance;
-}
-
 /* Tech stack icon row — replaces the comma-separated meta text. Monochrome
    gold-tinted glyphs read instantly and give the hero visual rhythm. */
 .hero-stack-row {
@@ -938,9 +927,10 @@ a {
   display: block;
   object-fit: cover;
   filter: saturate(0.92) contrast(1.04) brightness(0.94);
-  transition:
-    transform 450ms var(--ease-editorial),
-    filter 250ms var(--ease-editorial);
+  /* Only transform animates — the hover filter delta (saturate .92->.98) is
+     imperceptible, and animating filter forces a per-frame repaint of a large
+     image. Letting it snap keeps the zoom on the compositor. */
+  transition: transform 450ms var(--ease-editorial);
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -1346,10 +1336,6 @@ a {
     justify-content: flex-start;
   }
 
-  .hero-meta {
-    margin: 1rem 0 0;
-  }
-
   .hero-proof-list {
     justify-content: flex-start;
   }
@@ -1441,10 +1427,6 @@ a {
 
   .hero-name {
     font-size: clamp(3rem, 17vw, 5rem);
-  }
-
-  .hero-meta {
-    font-size: 0.68rem;
   }
 
   .hero-proof-list {


### PR DESCRIPTION
Full audit (performance / factual / visual) via 3 parallel reviewers. Site was already strong — 97/100/100/100, 25 tests, 0 vulns, clean a11y. These are the defensible deltas.

## Implemented
- **Dead CSS** — removed `.hero-meta` (base rule + 2 media overrides). The hero migrated to an icon row that replaced the old comma-separated meta text; the class is referenced in zero JSX.
- **Cheaper hover** — dropped `filter` from the `.project-image` transition. Hover delta (saturate .92→.98) is imperceptible; animating it forces a per-frame repaint of a large image over 250ms. Transform-only keeps the zoom on the compositor.
- **SEO** — added `public/sitemap.xml` + a `Sitemap:` directive in `robots.txt`.

## Audited & rejected (with reasons)
- **`React.memo(RevealItem)`** — a reviewer flagged ~17 unmemoized instances. Rejected: RevealItem receives `children` as inline JSX (new ref every render), so `memo` is defeated. Its parents are route components that only render during the 180 ms exit transition. No real benefit, adds overhead.
- **Index keys on About proof list** — current `key={item}` (unique strings on a static array) is correct; the suggested index keys are strictly worse.
- **Nav `backdrop-filter`, hero `drop-shadow`, card `box-shadow` transition** — real paint costs but visible design signatures with low actual impact (one card at a time / one-time above-fold paint). Left intact — no gratuitous design changes.

## Factual audit
All README claims re-verified against source: tech-stack versions vs `package.json`, script descriptions, project links, image asset integrity (all 10 portfolio WebPs + favicons + OG image exist), 100% of `target="_blank"` links carry `rel="noopener noreferrer"`, JSON-LD + manifest + theme-color consistent. No errors found.

## Visual audit
All 12 visual-smoke screenshots reviewed (360/390/1440 × 4 routes). No overflow, no missing alts, no console errors.

## Verification
- `npm run check` → 25/25 tests, format/lint/build clean
- `VISUAL_SMOKE_PORT=4174 npm run visual:smoke` → 12/12 pass
- Lighthouse (headless): **97 / 100 / 100 / 100** · LCP 2.3 s · CLS 0.001 · TBT 0 ms — unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)