### PR TITLE
Remove decorative section/card numbering

### DIFF
--- a/src/components/About/index.jsx
+++ b/src/components/About/index.jsx
@@ -25,9 +25,7 @@ function About() {
 
   return (
     <article className="about-panel">
-      <p className="section-eyebrow">
-        <span className="section-eyebrow-num">01</span> Introduction
-      </p>
+      <p className="section-eyebrow">Introduction</p>
       <div className="about-header-wrap">
         <p className="hero-kicker">Software Engineer</p>
         <div className="hero-grid">
@@ -89,27 +87,18 @@ function About() {
       <div className="about-highlight-grid">
         <RevealItem delay={0}>
           <div className="highlight-item highlight-item--feature">
-            <span className="highlight-num" aria-hidden="true">
-              01
-            </span>
             <h3>Core Stack</h3>
             <p>React, Next.js, Node.js, TypeScript, Java, Python</p>
           </div>
         </RevealItem>
         <RevealItem delay={1}>
           <div className="highlight-item">
-            <span className="highlight-num" aria-hidden="true">
-              02
-            </span>
             <h3>Focus</h3>
             <p>Production-ready systems, practical UX, and maintainable implementation</p>
           </div>
         </RevealItem>
         <RevealItem delay={2}>
           <div className="highlight-item">
-            <span className="highlight-num" aria-hidden="true">
-              03
-            </span>
             <h3>GitHub</h3>
             <p>Public build history and real project code at github.com/coleyrockin</p>
           </div>

--- a/src/components/Contact/index.jsx
+++ b/src/components/Contact/index.jsx
@@ -5,9 +5,7 @@ import RevealItem from "../RevealItem";
 function Contact() {
   return (
     <article className="contact-panel">
-      <p className="section-eyebrow">
-        <span className="section-eyebrow-num">04</span> Contact
-      </p>
+      <p className="section-eyebrow">Contact</p>
       <h2 className="panel-title">Contact</h2>
       <p className="contact-intro">
         For engineering opportunities, reach me directly by email, LinkedIn, or GitHub.

--- a/src/components/Knowledge/index.jsx
+++ b/src/components/Knowledge/index.jsx
@@ -10,9 +10,7 @@ import {
 function Knowledge() {
   return (
     <article className="knowledge-panel">
-      <p className="section-eyebrow">
-        <span className="section-eyebrow-num">03</span> Engineering Depth
-      </p>
+      <p className="section-eyebrow">Engineering Depth</p>
       <h2 className="panel-title">Engineering Knowledge</h2>
       <p className="knowledge-intro">
         Technologies and capabilities reflected in shipped work, with public references on GitHub.

--- a/src/components/Portfolio/index.jsx
+++ b/src/components/Portfolio/index.jsx
@@ -10,7 +10,7 @@ const projectsByPriority = [
   ...projects.filter((project) => !project.featured),
 ];
 
-const ProjectCard = memo(function ProjectCard({ project, isLead = false, index = 0 }) {
+const ProjectCard = memo(function ProjectCard({ project, isLead = false }) {
   const [imageFailed, setImageFailed] = useState(!project.image);
   // Cheap slice + join — useMemo's bookkeeping costs more than the work and
   // the parent <ProjectCard /> is already memo'd, so reference stability of
@@ -26,13 +26,9 @@ const ProjectCard = memo(function ProjectCard({ project, isLead = false, index =
   ]
     .filter(Boolean)
     .join(" ");
-  const projectNum = String(index + 1).padStart(2, "0");
 
   return (
     <article className={cardClass}>
-      <span className="project-num" aria-hidden="true">
-        {projectNum}
-      </span>
       {project.featured && (
         <p className="project-featured-tag" aria-hidden="true">
           Featured Case Study
@@ -131,9 +127,7 @@ const ProjectCard = memo(function ProjectCard({ project, isLead = false, index =
 function Portfolio() {
   return (
     <section className="portfolio-panel portfolio-panel--minimal">
-      <p className="section-eyebrow">
-        <span className="section-eyebrow-num">02</span> Selected Work · {projects.length} Projects
-      </p>
+      <p className="section-eyebrow">Selected Work · {projects.length} Projects</p>
       <h2 className="panel-title">Selected Work</h2>
       <p className="project-note">
         Minimal case studies from real builds, focused on outcomes, architecture choices, and
@@ -142,7 +136,7 @@ function Portfolio() {
       <div className="project-grid project-grid--symmetrical">
         {projectsByPriority.map((project, i) => (
           <RevealItem delay={Math.min(i, 5)} key={project.name}>
-            <ProjectCard project={project} isLead={i === 0} index={i} />
+            <ProjectCard project={project} isLead={i === 0} />
           </RevealItem>
         ))}
       </div>

--- a/src/editorial.css
+++ b/src/editorial.css
@@ -878,33 +878,6 @@ a {
   }
 }
 
-/* Editorial project numeral — sits in the content area's upper right and
-   acts as a faded ordinal marker matching the About highlight grid. */
-.project-num {
-  position: absolute;
-  z-index: 2;
-  bottom: 14px;
-  right: 18px;
-  color: var(--gold);
-  font-family: "Instrument Serif", Georgia, serif;
-  font-size: clamp(3.4rem, 6vw, 5.6rem);
-  font-weight: 400;
-  font-style: italic;
-  letter-spacing: -0.03em;
-  line-height: 1;
-  opacity: 0.12;
-  pointer-events: none;
-  user-select: none;
-}
-
-.project-card--featured .project-num,
-.project-card--lead .project-num {
-  font-size: clamp(4.6rem, 9vw, 8rem);
-  opacity: 0.16;
-  bottom: 18px;
-  right: 22px;
-}
-
 .project-image-link {
   position: relative;
   display: block;
@@ -1509,32 +1482,16 @@ a {
    Editorial polish layer (added in roadmap pass)
    ───────────────────────────────────────────────────────────────────── */
 
-/* Section eyebrows: small-caps numbered kicker that opens each section */
+/* Section eyebrows: small-caps kicker that opens each section */
 .section-eyebrow {
   margin: 0 0 12px;
   display: inline-flex;
   align-items: center;
-  gap: 0.6rem;
   color: var(--muted);
   font-size: 0.72rem;
   font-weight: var(--weight-label);
   letter-spacing: 0.18em;
   text-transform: uppercase;
-}
-
-.section-eyebrow-num {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.2rem 0.62rem;
-  border: 1px solid var(--gold-border-strong);
-  border-radius: 999px;
-  background: var(--gold-soft);
-  color: var(--gold);
-  font-family: "Instrument Serif", Georgia, serif;
-  font-size: 0.84rem;
-  font-style: italic;
-  font-weight: 400;
-  letter-spacing: 0.04em;
 }
 
 /* Gold hairline above each section panel */
@@ -1587,31 +1544,6 @@ a {
 .tier-sep {
   margin: 0 0.15rem;
   color: var(--faint);
-}
-
-/* Numbered highlight cards (Core Stack / Focus / GitHub) — huge faded
-   editorial numeral sits behind the card content as a decorative anchor. */
-.highlight-num {
-  position: absolute;
-  top: -0.18em;
-  right: 0.12em;
-  z-index: 0;
-  color: var(--gold);
-  font-family: "Instrument Serif", Georgia, serif;
-  font-size: clamp(5rem, 11vw, 9rem);
-  font-weight: 400;
-  letter-spacing: -0.04em;
-  line-height: 1;
-  font-style: italic;
-  opacity: 0.1;
-  pointer-events: none;
-  user-select: none;
-}
-
-.highlight-item--feature .highlight-num {
-  font-size: clamp(7rem, 16vw, 13rem);
-  opacity: 0.14;
-  top: -0.22em;
 }
 
 .highlight-item > h3,
@@ -1684,10 +1616,6 @@ a {
   .section-eyebrow {
     font-size: 0.64rem;
     margin-bottom: 10px;
-  }
-  .section-eyebrow-num {
-    font-size: 0.56rem;
-    padding: 0.15rem 0.45rem;
   }
   .footer-copy {
     text-align: center;


### PR DESCRIPTION
Drop all the `01/02/03` ornamental numerals. They restated order the section labels and the nav already convey — removing them reads cleaner and more confident.

## Changes
- **Section eyebrows** — "01 Introduction" → "Introduction" across all four sections.
- **About highlight cards** — remove the giant faded 01/02/03 backdrop numerals.
- **Portfolio cards** — remove the per-card ordinal; drop the now-unused `index` prop from `ProjectCard`.
- **CSS** — delete the dead rules (`.section-eyebrow-num`, `.highlight-num`, `.project-num` + responsive overrides), tidy `.section-eyebrow`. Net −100 lines / +7.

## Verification
- `npm run check` → 36/36, format/lint/build clean
- `VISUAL_SMOKE_PORT=4174 npm run visual:smoke` → 12/12; layout intact at 360/390/1440, no leftover gaps where numerals sat

🤖 Generated with [Claude Code](https://claude.com/claude-code)