### PR TITLE
Fix Contact dead zone: balance short sections + availability anchor

### DIFF
--- a/src/components/Contact/index.jsx
+++ b/src/components/Contact/index.jsx
@@ -8,7 +8,8 @@ function Contact() {
       <p className="section-eyebrow">Contact</p>
       <h2 className="panel-title">Contact</h2>
       <p className="contact-intro">
-        For engineering opportunities, reach me directly by email, LinkedIn, or GitHub.
+        For full-time, contract, or advisory opportunities — reach me directly by email, LinkedIn,
+        or GitHub.
       </p>
 
       <section className="social-grid" aria-label="Social Profiles">
@@ -33,6 +34,8 @@ function Contact() {
           );
         })}
       </section>
+
+      <p className="contact-availability">Based in Central Texas · open to remote</p>
     </article>
   );
 }

--- a/src/editorial.css
+++ b/src/editorial.css
@@ -238,11 +238,18 @@ a {
 
 .main-content {
   flex: 1;
+  display: flex;
+  flex-direction: column;
   margin-top: clamp(38px, 6vw, 70px);
   margin-bottom: clamp(34px, 6vw, 72px);
 }
 
 .content-shell {
+  /* margin-block:auto vertically centres short sections (e.g. Contact) so the
+     leftover space splits evenly above + below instead of pooling into a dead
+     zone above the bottom-pinned footer. Tall sections have no free space, so
+     it resolves to 0 — no clipping, unlike justify-content: center. */
+  margin-block: auto;
   animation: sectionIn var(--motion-section) var(--ease-editorial);
 }
 
@@ -635,6 +642,21 @@ a {
   margin: 1.35rem auto 0;
   color: var(--muted);
   text-wrap: balance;
+}
+
+/* Closing line under the social grid: a hairline + locale/availability note
+   gives the Contact section a deliberate bottom edge so it never ends abruptly
+   at the cards. Mirrors the footer's uppercase micro-label language. */
+.contact-availability {
+  width: min(520px, 100%);
+  margin: clamp(30px, 4.5vw, 48px) auto 0;
+  padding-top: clamp(20px, 3vw, 30px);
+  border-top: 1px solid var(--line);
+  color: var(--faint);
+  font-size: 0.78rem;
+  font-weight: var(--weight-label);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
 .about-highlight-grid,


### PR DESCRIPTION
## What

Fixes the ~350px empty void between the Contact social cards and the footer on desktop (ROADMAP #1, critical), plus the passive contact copy (ROADMAP #2).

## Root cause

Not `.contact-panel` min-height as the roadmap guessed. It's the sticky-footer pattern: `.app-shell` is `min-height:100vh` flex column and `.main-content` is `flex:1`, so on short routes content hugs the top of a tall `main` while the footer pins to the bottom.

## Changes

- **Balance short sections** — `margin-block:auto` on `.content-shell`. Splits leftover space evenly above/below. Resolves to `0` when content overflows, so the tall sections (About, Portfolio, Knowledge) are untouched — no top-clipping (verified via visual smoke).
- **Tighten copy** — "engineering opportunities" → "full-time, contract, or advisory opportunities".
- **Closing anchor** — hairline + "Based in Central Texas · open to remote" gives the section a deliberate bottom edge.

## Verification

- `npm run check` — 36 tests pass, lint clean, build succeeds
- `npm run visual:smoke` — 12 shots; Contact balanced, Knowledge (tall) renders full with no clip

🤖 Generated with [Claude Code](https://claude.com/claude-code)